### PR TITLE
Pageable APIs

### DIFF
--- a/src/main/kotlin/com/bitclave/node/controllers/v1/PageableController.kt
+++ b/src/main/kotlin/com/bitclave/node/controllers/v1/PageableController.kt
@@ -2,7 +2,9 @@ package com.bitclave.node.controllers.v1
 
 import com.bitclave.node.controllers.AbstractController
 import com.bitclave.node.repository.models.Offer
+import com.bitclave.node.repository.models.OfferSearch
 import com.bitclave.node.repository.models.SearchRequest
+import com.bitclave.node.services.v1.OfferSearchService
 import com.bitclave.node.services.v1.OfferService
 import com.bitclave.node.services.v1.SearchRequestService
 import io.swagger.annotations.ApiOperation
@@ -12,8 +14,6 @@ import io.swagger.annotations.ApiResponses
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Sort
-import org.springframework.data.domain.Sort.Direction.*
 import org.springframework.web.bind.annotation.*
 import java.util.concurrent.CompletableFuture
 
@@ -21,7 +21,8 @@ import java.util.concurrent.CompletableFuture
 @RequestMapping("/v1/")
 class PageableController(
         @Qualifier("v1") private val offerService: OfferService,
-        @Qualifier("v1") private val searchRequestService: SearchRequestService
+        @Qualifier("v1") private val searchRequestService: SearchRequestService,
+        @Qualifier("v1") private val offerSearchService: OfferSearchService
 ) : AbstractController() {
 
     @ApiOperation(
@@ -45,17 +46,11 @@ class PageableController(
         strategy: String?): CompletableFuture<Page<Offer>> {
 
         if(page == null || size == null) {
-            return offerService.getPageableOffers(
-                    PageRequest(0, 20, Sort(ASC,"id")),
-                    getStrategyType(strategy)
+            return offerService.getPageableOffers(PageRequest(0, 20), getStrategyType(strategy)
             )
         }
 
-        return offerService.getPageableOffers(PageRequest(
-                page,
-                size,
-                Sort(ASC,"id")
-        ), getStrategyType(strategy))
+        return offerService.getPageableOffers(PageRequest(page, size), getStrategyType(strategy))
     }
 
     @ApiOperation(
@@ -81,13 +76,42 @@ class PageableController(
 
         if(page == null || size == null) {
             return searchRequestService.getPageableRequests(
-                    PageRequest(0, 20, Sort(ASC,"id")),
-                    getStrategyType(strategy)
+                    PageRequest(0, 20), getStrategyType(strategy)
             )
         }
 
         return searchRequestService.getPageableRequests(
-                PageRequest(page, size, Sort(ASC,"id")),
-                getStrategyType(strategy))
+                PageRequest(page, size), getStrategyType(strategy))
+    }
+
+    @ApiOperation(
+            "Page through already created offersearch results",
+            response = OfferSearch::class, responseContainer = "Page"
+    )
+    @ApiResponses(value = [
+        ApiResponse(code = 200, message = "Success", response = Page::class)
+    ])
+    @RequestMapping(value = "search/results", method = [RequestMethod.GET], params = [ "page", "size"])
+    fun getPageableOfferSearch(
+            @ApiParam("Optional page number to retrieve a particular page. If not specified this API retrieves first page.")
+            @RequestParam( "page" )
+            page: Int?,
+
+            @ApiParam("Optional page size to include number of offers in a page. Defaults to 20.")
+            @RequestParam( "size" )
+            size: Int?,
+
+            @ApiParam("change repository strategy", allowableValues = "POSTGRES, HYBRID", required = false)
+            @RequestHeader("Strategy", required = false)
+            strategy: String?): CompletableFuture<Page<OfferSearch>> {
+
+        if(page == null || size == null) {
+            return offerSearchService.getPageableOfferSearches(
+                    PageRequest(0, 20), getStrategyType(strategy)
+            )
+        }
+
+        return offerSearchService.getPageableOfferSearches(
+                PageRequest(page, size), getStrategyType(strategy))
     }
 }

--- a/src/main/kotlin/com/bitclave/node/controllers/v1/PageableController.kt
+++ b/src/main/kotlin/com/bitclave/node/controllers/v1/PageableController.kt
@@ -1,0 +1,93 @@
+package com.bitclave.node.controllers.v1
+
+import com.bitclave.node.controllers.AbstractController
+import com.bitclave.node.repository.models.Offer
+import com.bitclave.node.repository.models.SearchRequest
+import com.bitclave.node.services.v1.OfferService
+import com.bitclave.node.services.v1.SearchRequestService
+import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiParam
+import io.swagger.annotations.ApiResponse
+import io.swagger.annotations.ApiResponses
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.data.domain.Sort.Direction.*
+import org.springframework.web.bind.annotation.*
+import java.util.concurrent.CompletableFuture
+
+@RestController
+@RequestMapping("/v1/")
+class PageableController(
+        @Qualifier("v1") private val offerService: OfferService,
+        @Qualifier("v1") private val searchRequestService: SearchRequestService
+) : AbstractController() {
+
+    @ApiOperation(
+            "Page through already created offers", response = Offer::class, responseContainer = "Page"
+    )
+    @ApiResponses(value = [
+        ApiResponse(code = 200, message = "Success", response = Page::class)
+    ])
+    @RequestMapping(value = "offers", method = [RequestMethod.GET], params = [ "page", "size"])
+    fun getPageableOffers(
+        @ApiParam("Optional page number to retrieve a particular page. If not specified this API retrieves first page.")
+        @RequestParam( "page" )
+        page: Int?,
+
+        @ApiParam("Optional page size to include number of offers in a page. Defaults to 20.")
+        @RequestParam( "size" )
+        size: Int?,
+
+        @ApiParam("change repository strategy", allowableValues = "POSTGRES, HYBRID", required = false)
+        @RequestHeader("Strategy", required = false)
+        strategy: String?): CompletableFuture<Page<Offer>> {
+
+        if(page == null || size == null) {
+            return offerService.getPageableOffers(
+                    PageRequest(0, 20, Sort(ASC,"id")),
+                    getStrategyType(strategy)
+            )
+        }
+
+        return offerService.getPageableOffers(PageRequest(
+                page,
+                size,
+                Sort(ASC,"id")
+        ), getStrategyType(strategy))
+    }
+
+    @ApiOperation(
+            "Page through already created search requests",
+            response = SearchRequest::class, responseContainer = "Page"
+    )
+    @ApiResponses(value = [
+        ApiResponse(code = 200, message = "Success", response = Page::class)
+    ])
+    @RequestMapping(value = "search/requests", method = [RequestMethod.GET], params = [ "page", "size"])
+    fun getPageableSearchRequests(
+            @ApiParam("Optional page number to retrieve a particular page. If not specified this API retrieves first page.")
+            @RequestParam( "page" )
+            page: Int?,
+
+            @ApiParam("Optional page size to include number of offers in a page. Defaults to 20.")
+            @RequestParam( "size" )
+            size: Int?,
+
+            @ApiParam("change repository strategy", allowableValues = "POSTGRES, HYBRID", required = false)
+            @RequestHeader("Strategy", required = false)
+            strategy: String?): CompletableFuture<Page<SearchRequest>> {
+
+        if(page == null || size == null) {
+            return searchRequestService.getPageableRequests(
+                    PageRequest(0, 20, Sort(ASC,"id")),
+                    getStrategyType(strategy)
+            )
+        }
+
+        return searchRequestService.getPageableRequests(
+                PageRequest(page, size, Sort(ASC,"id")),
+                getStrategyType(strategy))
+    }
+}

--- a/src/main/kotlin/com/bitclave/node/repository/offer/OfferCrudRepository.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/offer/OfferCrudRepository.kt
@@ -1,13 +1,16 @@
 package com.bitclave.node.repository.offer
 
 import com.bitclave.node.repository.models.Offer
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 
 @Repository
 @Transactional
-interface OfferCrudRepository : CrudRepository<Offer, Long> {
+interface OfferCrudRepository : PagingAndSortingRepository<Offer, Long> {
 
     fun findByOwner(owner: String): List<Offer>
 

--- a/src/main/kotlin/com/bitclave/node/repository/offer/OfferRepository.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/offer/OfferRepository.kt
@@ -1,6 +1,8 @@
 package com.bitclave.node.repository.offer
 
 import com.bitclave.node.repository.models.Offer
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface OfferRepository {
 
@@ -20,4 +22,5 @@ interface OfferRepository {
 
     fun findAll(): List<Offer>
 
+    fun findAll(pageable: Pageable): Page<Offer>
 }

--- a/src/main/kotlin/com/bitclave/node/repository/offer/PostgresOfferRepositoryImpl.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/offer/PostgresOfferRepositoryImpl.kt
@@ -5,6 +5,8 @@ import com.bitclave.node.repository.models.OfferResultAction
 import com.bitclave.node.repository.search.offer.OfferSearchCrudRepository
 import com.bitclave.node.services.errors.DataNotSavedException
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
@@ -68,4 +70,7 @@ class PostgresOfferRepositoryImpl(
                 .toList()
     }
 
+    override fun findAll(pageable: Pageable): Page<Offer> {
+        return repository.findAll(pageable)
+    }
 }

--- a/src/main/kotlin/com/bitclave/node/repository/search/PostgresSearchRequestRepositoryImpl.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/search/PostgresSearchRequestRepositoryImpl.kt
@@ -7,6 +7,8 @@ import com.bitclave.node.repository.search.offer.OfferSearchCrudRepository
 import com.bitclave.node.services.errors.DataNotSavedException
 import com.bitclave.node.services.errors.NotFoundException
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
@@ -56,7 +58,7 @@ class PostgresSearchRequestRepositoryImpl(
                 .toList()
     }
 
-    override fun cloneSearchRequestWithOfferSearches(request: SearchRequest): SearchRequest {
+     override fun cloneSearchRequestWithOfferSearches(request: SearchRequest): SearchRequest {
         var existingRequest = repository.findOne(request.id)
         if(existingRequest == null) return throw NotFoundException()
 
@@ -87,4 +89,7 @@ class PostgresSearchRequestRepositoryImpl(
         return createSearchRequest
     }
 
+    override fun findAll(pageable: Pageable): Page<SearchRequest> {
+        return repository.findAll(pageable)
+    }
 }

--- a/src/main/kotlin/com/bitclave/node/repository/search/SearchRequestCrudRepository.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/search/SearchRequestCrudRepository.kt
@@ -1,13 +1,13 @@
 package com.bitclave.node.repository.search
 
 import com.bitclave.node.repository.models.SearchRequest
-import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 
 @Repository
 @Transactional
-interface SearchRequestCrudRepository : CrudRepository<SearchRequest, Long> {
+interface SearchRequestCrudRepository : PagingAndSortingRepository<SearchRequest, Long> {
 
     fun findById(id: Long): List<SearchRequest>
 

--- a/src/main/kotlin/com/bitclave/node/repository/search/SearchRequestRepository.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/search/SearchRequestRepository.kt
@@ -1,6 +1,8 @@
 package com.bitclave.node.repository.search
 
 import com.bitclave.node.repository.models.SearchRequest
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface SearchRequestRepository {
 
@@ -20,4 +22,5 @@ interface SearchRequestRepository {
 
     fun cloneSearchRequestWithOfferSearches(request: SearchRequest): SearchRequest
 
+    fun findAll(pageable: Pageable): Page<SearchRequest>
 }

--- a/src/main/kotlin/com/bitclave/node/repository/search/offer/OfferSearchCrudRepository.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/search/offer/OfferSearchCrudRepository.kt
@@ -2,12 +2,13 @@ package com.bitclave.node.repository.search.offer
 
 import com.bitclave.node.repository.models.OfferSearch
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 
 @Repository
 @Transactional
-interface OfferSearchCrudRepository : CrudRepository<OfferSearch, Long> {
+interface OfferSearchCrudRepository : PagingAndSortingRepository<OfferSearch, Long> {
 
     fun findBySearchRequestId(id: Long): List<OfferSearch>
 

--- a/src/main/kotlin/com/bitclave/node/repository/search/offer/OfferSearchRepository.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/search/offer/OfferSearchRepository.kt
@@ -1,6 +1,8 @@
 package com.bitclave.node.repository.search.offer
 
 import com.bitclave.node.repository.models.OfferSearch
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface OfferSearchRepository {
 
@@ -17,5 +19,7 @@ interface OfferSearchRepository {
     fun findBySearchRequestIdAndOfferId(searchRequestId: Long, offerId: Long): List<OfferSearch>
 
     fun findByOwnerAndOfferId(owner: String, offerId: Long): List<OfferSearch>
+
+    fun findAll(pageable: Pageable): Page<OfferSearch>
 
 }

--- a/src/main/kotlin/com/bitclave/node/repository/search/offer/PostgresOfferSearchRepositoryImpl.kt
+++ b/src/main/kotlin/com/bitclave/node/repository/search/offer/PostgresOfferSearchRepositoryImpl.kt
@@ -4,6 +4,8 @@ import com.bitclave.node.repository.models.OfferSearch
 import com.bitclave.node.repository.search.SearchRequestCrudRepository
 import com.bitclave.node.services.errors.DataNotSavedException
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
@@ -74,5 +76,9 @@ class PostgresOfferSearchRepositoryImpl(
         val offerSearchList = repository.findByOfferId(offerId)
 
         return offerSearchList.filter { searchRequestIDs.contains(it.searchRequestId) }
+    }
+
+    override fun findAll(pageable: Pageable): Page<OfferSearch> {
+        return repository.findAll(pageable)
     }
 }

--- a/src/main/kotlin/com/bitclave/node/services/v1/OfferSearchService.kt
+++ b/src/main/kotlin/com/bitclave/node/services/v1/OfferSearchService.kt
@@ -13,6 +13,8 @@ import com.bitclave.node.repository.search.offer.OfferSearchRepository
 import com.bitclave.node.services.errors.AccessDeniedException
 import com.bitclave.node.services.errors.BadArgumentException
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import java.util.concurrent.CompletableFuture
 import com.google.gson.Gson
@@ -313,6 +315,15 @@ class OfferSearchService(
             else
                 return@supplyAsync repository.findByOfferId(offerId)
 
+        }
+    }
+
+    fun getPageableOfferSearches(page: PageRequest,
+                                 strategy: RepositoryStrategyType
+    ): CompletableFuture<Page<OfferSearch>> {
+        return CompletableFuture.supplyAsync {
+            val repository = offerSearchRepository.changeStrategy(strategy)
+            return@supplyAsync repository.findAll(page)
         }
     }
 }

--- a/src/main/kotlin/com/bitclave/node/services/v1/OfferService.kt
+++ b/src/main/kotlin/com/bitclave/node/services/v1/OfferService.kt
@@ -3,12 +3,13 @@ package com.bitclave.node.services.v1
 import com.bitclave.node.repository.RepositoryStrategy
 import com.bitclave.node.repository.RepositoryStrategyType
 import com.bitclave.node.repository.models.Offer
-import com.bitclave.node.repository.models.OfferPrice
 import com.bitclave.node.repository.offer.OfferRepository
 import com.bitclave.node.repository.price.OfferPriceRepository
 import com.bitclave.node.services.errors.BadArgumentException
 import com.bitclave.node.services.errors.NotFoundException
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import java.util.concurrent.CompletableFuture
 
@@ -116,4 +117,12 @@ class OfferService(
         })
     }
 
+    fun getPageableOffers(page: PageRequest,
+                          strategy: RepositoryStrategyType
+    ): CompletableFuture<Page<Offer>> {
+        return CompletableFuture.supplyAsync {
+            val repository = offerRepository.changeStrategy(strategy)
+            return@supplyAsync repository.findAll(page)
+        }
+    }
 }

--- a/src/main/kotlin/com/bitclave/node/services/v1/SearchRequestService.kt
+++ b/src/main/kotlin/com/bitclave/node/services/v1/SearchRequestService.kt
@@ -6,6 +6,8 @@ import com.bitclave.node.repository.models.SearchRequest
 import com.bitclave.node.repository.search.SearchRequestRepository
 import com.bitclave.node.services.errors.NotFoundException
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import java.util.concurrent.CompletableFuture
 
@@ -99,6 +101,17 @@ class SearchRequestService(
 
             repository.changeStrategy(strategy).cloneSearchRequestWithOfferSearches(clonedSearchRequest)
         })
+    }
+
+    fun getPageableRequests(
+            page: PageRequest,
+            strategy: RepositoryStrategyType
+    ): CompletableFuture<Page<SearchRequest>> {
+
+        return CompletableFuture.supplyAsync {
+            val repository = repository.changeStrategy(strategy)
+            return@supplyAsync repository.findAll(page)
+        }
     }
 
 }

--- a/src/test/kotlin/com/bitclave/node/RunAllTests.kt
+++ b/src/test/kotlin/com/bitclave/node/RunAllTests.kt
@@ -13,6 +13,8 @@ import com.bitclave.node.requestData.RequestDataServiceHybridTest
 import com.bitclave.node.requestData.RequestDataServiceTest
 import com.bitclave.node.search.SearchRequestControllerTest
 import com.bitclave.node.search.SearchRequestServiceTest
+import com.bitclave.node.search.offer.OfferSearchControllerTest
+import com.bitclave.node.search.offer.OfferSearchServiceTest
 import com.bitclave.node.share.OfferShareControllerTest
 import com.bitclave.node.share.OfferShareServiceTest
 import org.junit.runner.RunWith
@@ -33,6 +35,8 @@ import org.junit.runners.Suite
     OfferServiceTest::class,
     SearchRequestControllerTest::class,
     SearchRequestServiceTest::class,
+    OfferSearchControllerTest::class,
+    OfferSearchServiceTest::class,
     OfferShareControllerTest::class,
     OfferShareServiceTest::class
 ])

--- a/src/test/kotlin/com/bitclave/node/offer/OfferControllerTest.kt
+++ b/src/test/kotlin/com/bitclave/node/offer/OfferControllerTest.kt
@@ -138,9 +138,6 @@ class OfferControllerTest {
                 .headers(httpHeaders))
                 .andExpect(status().isOk)
                 .andReturn()
-
-        val content = result.response.contentAsString
-        println("Sai>>>>>$content")
     }
 
     @Test

--- a/src/test/kotlin/com/bitclave/node/offer/OfferControllerTest.kt
+++ b/src/test/kotlin/com/bitclave/node/offer/OfferControllerTest.kt
@@ -16,7 +16,9 @@ import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.math.BigDecimal
 
@@ -138,7 +140,14 @@ class OfferControllerTest {
                 .andReturn()
 
         val content = result.response.contentAsString
-        println(content)
+        println("Sai>>>>>$content")
     }
 
+    @Test
+    fun `get offers by page`() {
+        val result = this.mvc.perform(MockMvcRequestBuilders.get("/$version/offers?page=0&size=2")
+                .headers(httpHeaders))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn()
+    }
 }

--- a/src/test/kotlin/com/bitclave/node/offer/OfferServiceTest.kt
+++ b/src/test/kotlin/com/bitclave/node/offer/OfferServiceTest.kt
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith
 import org.mockito.internal.matchers.Null
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
@@ -297,4 +298,20 @@ class OfferServiceTest {
         assertThat(result[1]).isEqualToIgnoringGivenFields(offer, "id","offerPrices")
     }
 
+    @Test fun `should return all offers by page`() {
+        `should be create new offer`()
+        `should be create new offer`()
+        `should be create new offer`()
+        `should be create new offer`()
+
+        val firstPage = offerService.getPageableOffers(PageRequest(0, 2), strategy).get()
+        assertThat(firstPage.size).isEqualTo(2)
+        assert(firstPage.first().id == 1L)
+        assert(firstPage.last().id == 2L)
+
+        val secondPage = offerService.getPageableOffers(PageRequest(1, 2), strategy).get()
+        assertThat(secondPage.size).isEqualTo(2)
+        assert(secondPage.first().id == 3L)
+        assert(secondPage.last().id == 4L)
+    }
 }

--- a/src/test/kotlin/com/bitclave/node/search/SearchRequestControllerTest.kt
+++ b/src/test/kotlin/com/bitclave/node/search/SearchRequestControllerTest.kt
@@ -91,4 +91,10 @@ class SearchRequestControllerTest {
                 .andExpect(status().isCreated)
     }
 
+    @Test fun `get search requests by page`() {
+        this.mvc.perform(get("/$version/search/requests?page=0&size=2")
+                .headers(httpHeaders))
+                .andExpect(status().isOk)
+    }
+
 }

--- a/src/test/kotlin/com/bitclave/node/search/SearchRequestServiceTest.kt
+++ b/src/test/kotlin/com/bitclave/node/search/SearchRequestServiceTest.kt
@@ -31,6 +31,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
@@ -252,4 +253,20 @@ class SearchRequestServiceTest {
         assert(clonedOfferSearches[1].offerSearch.state == OfferResultAction.NONE)
     }
 
+    @Test fun `should return all search requests by page`() {
+        `should be create new search request`()
+        `should be create new search request`()
+        `should be create new search request`()
+        `should be create new search request`()
+
+        val firstPage = searchRequestService.getPageableRequests(PageRequest(0, 2), strategy).get()
+        assertThat(firstPage.size).isEqualTo(2)
+        assert(firstPage.first().id == 1L)
+        assert(firstPage.last().id == 2L)
+
+        val secondPage = searchRequestService.getPageableRequests(PageRequest(1, 2), strategy).get()
+        assertThat(secondPage.size).isEqualTo(2)
+        assert(secondPage.first().id == 3L)
+        assert(secondPage.last().id == 4L)
+    }
 }

--- a/src/test/kotlin/com/bitclave/node/search/offer/OfferSearchControllerTest.kt
+++ b/src/test/kotlin/com/bitclave/node/search/offer/OfferSearchControllerTest.kt
@@ -94,4 +94,9 @@ class OfferSearchControllerTest {
                 .andExpect(status().isCreated)
     }
 
+    @Test fun `get offer search by page`() {
+        this.mvc.perform(get("/$version/search/results?page=0&size=2")
+                .headers(httpHeaders))
+                .andExpect(status().isOk)
+    }
 }

--- a/src/test/kotlin/com/bitclave/node/search/offer/OfferSearchServiceTest.kt
+++ b/src/test/kotlin/com/bitclave/node/search/offer/OfferSearchServiceTest.kt
@@ -360,10 +360,9 @@ class OfferSearchServiceTest {
     }
 
     @Test fun `should return all offersearch results by page`() {
-
         LongStream.range(0, 4).forEach { id ->
             val offer = Offer(
-                    id,
+                    0,
                     businessPublicKey,
                     listOf(),
                     "desc",
@@ -373,7 +372,7 @@ class OfferSearchServiceTest {
 
             offerCrudRepository.save(offer)
 
-            val request = SearchRequest(id, publicKey, emptyMap())
+            val request = SearchRequest(0, publicKey, emptyMap())
             searchRequestCrudRepository.save(request)
 
             offerSearchService.saveNewOfferSearch(

--- a/src/test/kotlin/com/bitclave/node/search/offer/OfferSearchServiceTest.kt
+++ b/src/test/kotlin/com/bitclave/node/search/offer/OfferSearchServiceTest.kt
@@ -25,15 +25,21 @@ import com.bitclave.node.repository.share.OfferShareCrudRepository
 import com.bitclave.node.repository.share.OfferShareRepositoryStrategy
 import com.bitclave.node.repository.share.PostgresOfferShareRepositoryImpl
 import com.bitclave.node.services.v1.*
+import com.bitclave.node.services.v1.AccountService
+import com.bitclave.node.services.v1.OfferSearchService
+import com.bitclave.node.services.v1.OfferShareService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import java.math.BigDecimal
+import java.util.stream.LongStream
 
 @ActiveProfiles("test")
 @RunWith(SpringRunner::class)
@@ -353,4 +359,37 @@ class OfferSearchServiceTest {
         assert(result.isEmpty())
     }
 
+    @Test fun `should return all offersearch results by page`() {
+
+        LongStream.range(0, 4).forEach { id ->
+            val offer = Offer(
+                    id,
+                    businessPublicKey,
+                    listOf(),
+                    "desc",
+                    "title",
+                    "url"
+            )
+
+            offerCrudRepository.save(offer)
+
+            val request = SearchRequest(id, publicKey, emptyMap())
+            searchRequestCrudRepository.save(request)
+
+            offerSearchService.saveNewOfferSearch(
+                    OfferSearch(0, request.id, offer.id, OfferResultAction.NONE),
+                    strategy
+            ).get()
+        }
+
+        val firstPage = offerSearchService.getPageableOfferSearches(PageRequest(0, 2), strategy).get()
+        assertThat(firstPage.size).isEqualTo(2)
+        assert(firstPage.first().id == 1L)
+        assert(firstPage.last().id == 2L)
+
+        val secondPage = offerSearchService.getPageableOfferSearches(PageRequest(1, 2), strategy).get()
+        assertThat(secondPage.size).isEqualTo(2)
+        assert(secondPage.first().id == 3L)
+        assert(secondPage.last().id == 4L)
+    }
 }


### PR DESCRIPTION
* Added new pageable APIs to fetch offers, requests and offer searches.
* Paginations APIs return the response that would look like below where content holds the array of either offers or requests or offer searches.

```
{
	"content": [{
		"id": 1,
		"searchRequestId": 2,
		"offerId": 1,
		"state": "NONE",
		"lastUpdated": "Sat Feb 02 19:32:17 PST 2019",
		"info": "[\"created by base-matcher\"]",
		"events": []
	}],
	"last": true,
	"totalPages": 1,
	"totalElements": 1,
	"first": true,
	"sort": null,
	"numberOfElements": 1,
	"size": 1,
	"number": 0
}
```